### PR TITLE
feat : 로그인&회원가입 (3차) 타입 수정 / 로직 분리

### DIFF
--- a/src/pages/User/Login/LoginPage.tsx
+++ b/src/pages/User/Login/LoginPage.tsx
@@ -7,12 +7,67 @@ import { login } from '@/service/auth/login';
 import { getUserInfo } from '@/service/user/getUserInfo';
 import { Container } from '@/components/Common/Container/Container';
 import { useToastStore } from '@/hooks/useToastStore';
+import { LoginResponseType } from '@/types/login';
 
 export const LoginPage = () => {
     const navigate = useNavigate();
     const { setUser } = useUserStore();
     const { addToast } = useToastStore();
 
+    /**
+     * 로그인 이후 유저 정보 조회
+     * @param email
+     * @returns
+     */
+    const handleGetUserInfo = async (email: string) => {
+        const userInfoResponse = await getUserInfo();
+        if (!userInfoResponse) {
+            addToast('유저 정보를 불러오기를 실패했습니다.', 'warning');
+            return false;
+        }
+        const userInfoWithEmail = {
+            nickname: userInfoResponse.nickname || '알 수 없음',
+            profileImageUrl: userInfoResponse.profileImageUrl || 'testimg.jpg',
+            email: email
+        };
+        setUser(userInfoWithEmail);
+        return true;
+    };
+
+    /**
+     * 로그인 결과 처리
+     * @param loginResponse
+     * @param email
+     * @returns
+     */
+    const handleLoginResponse = async (
+        loginResponse: LoginResponseType,
+        email: string
+    ) => {
+        switch (loginResponse.code) {
+            case 'COMMON200': {
+                addToast('로그인에 성공했습니다.', 'success');
+                return await handleGetUserInfo(email);
+            }
+            case 'USER4000': {
+                addToast('유저를 찾을 수 없습니다.', 'warning');
+                return false;
+            }
+            case 'USER4001': {
+                addToast('비밀번호가 일치하지 않습니다.', 'warning');
+                return false;
+            }
+            default:
+                addToast('로그인 처리에 실패했습니다.', 'warning');
+                return false;
+        }
+    };
+
+    /**
+     * 로그인 폼 제출
+     * @param e
+     * @returns
+     */
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         const $loginForm = e.target as HTMLFormElement;
@@ -29,31 +84,12 @@ export const LoginPage = () => {
 
         try {
             const loginResponse = await login({ email, password });
-            console.log('응답 : ', loginResponse.code);
-
-            switch (loginResponse.code) {
-                case 'COMMON200': {
-                    addToast('로그인에 성공했습니다.', 'success');
-                    const userInfoResponse = await getUserInfo();
-                    const userInfoWithEmail = {
-                        ...userInfoResponse,
-                        email: email
-                    };
-                    setUser(userInfoWithEmail);
-                    navigate('/');
-                    break;
-                }
-                case 'USER4000': {
-                    addToast('유저를 찾을 수 없습니다.', 'warning');
-                    break;
-                }
-                case 'USER4001': {
-                    addToast('비밀번호가 일치하지 않습니다.', 'warning');
-                    break;
-                }
-                default:
-                    addToast('로그인 처리에 실패했습니다.', 'warning');
-                    break;
+            const isLoginSuccess = await handleLoginResponse(
+                loginResponse,
+                email
+            );
+            if (isLoginSuccess) {
+                navigate('/');
             }
         } catch (error) {
             console.error('에러: ', error);

--- a/src/service/auth/login.ts
+++ b/src/service/auth/login.ts
@@ -1,17 +1,12 @@
 import { AxiosError } from 'axios';
-import { LoginType } from '@/types/login';
 import { defaultApi } from '@/service/api';
 import { tokenStorage } from './tokenStorage';
-
-type LoginProps = {
-    email: string;
-    password: string;
-};
+import { LoginProps, LoginResponseType } from '@/types/login';
 
 export async function login({
     email,
     password
-}: LoginProps): Promise<LoginType> {
+}: LoginProps): Promise<LoginResponseType> {
     const api = defaultApi();
 
     try {

--- a/src/service/auth/tokenStorage.ts
+++ b/src/service/auth/tokenStorage.ts
@@ -9,7 +9,7 @@ export const tokenStorage = {
         localStorage.setItem(ACCESS_TOKEN_KEY, token);
     },
 
-    cleareTokens: (): void => {
+    clearTokens: (): void => {
         localStorage.removeItem(ACCESS_TOKEN_KEY);
     }
 };

--- a/src/service/user/getUserInfo.ts
+++ b/src/service/user/getUserInfo.ts
@@ -1,9 +1,8 @@
 import { AxiosError } from 'axios';
 import { defaultApi } from '@/service/api';
 import { UserType } from '@/types/user';
-import { ApiResponseType } from '@/types/apiResponse';
 
-type getUserInfoResponseType = ApiResponseType<UserType | null>;
+type getUserInfoResponseType = UserType | null;
 
 export async function getUserInfo(): Promise<getUserInfoResponseType> {
     const api = defaultApi();

--- a/src/types/apiResponse.ts
+++ b/src/types/apiResponse.ts
@@ -1,5 +1,5 @@
 export interface ApiResponseType<T> {
-    code: number;
+    code: string;
     status: string;
     message: string;
     result: T;

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,7 +1,7 @@
 import { UserType } from './user';
 
 type LoginType = {
-    code: number;
+    code: string;
     status: string;
     message: string;
     data: UserType;

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,10 +1,13 @@
-import { UserType } from './user';
+import { ApiResponseType } from './apiResponse';
 
-type LoginType = {
-    code: string;
-    status: string;
-    message: string;
-    data: UserType;
+export type LoginProps = {
+    email: string;
+    password: string;
 };
 
-export type { LoginType };
+export type TokenType = {
+    accessToken: string;
+    refreshToken: string;
+};
+
+export type LoginResponseType = ApiResponseType<TokenType | null>;


### PR DESCRIPTION
# 🚀요약
로그인&회원가입 (3차) 타입 수정 / 로직 분리

# 📸사진 (구현 캡처)

# 📝작업 내용

-   [x] 로그인 관련 타입 수정 (apiResponse의 code가 number로 되어있어서 수정했습니다.)
-   [x] refactor : 로그인 submit 함수 분리

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
기존 로그인타입은 추후에 삭제처리하겠습니다

close #212 
