### PR TITLE
feat : 로그인&회원가입 (4차) - 회원가입 페이지 수정

### DIFF
--- a/src/components/Common/Input/Input.tsx
+++ b/src/components/Common/Input/Input.tsx
@@ -58,9 +58,9 @@ export const Input = ({
             <div className="flex flex-row gap-2">
                 {text}
                 {error && (
-                    <p className="text-[14px] my-[2px] text-small text-red-500 md:text-base">
+                    <div className="text-xs my-[2px] text-red-500 md:text-base">
                         {error}
-                    </p>
+                    </div>
                 )}
             </div>
             <div>

--- a/src/components/RegisterPage/NicknameSection.tsx
+++ b/src/components/RegisterPage/NicknameSection.tsx
@@ -26,24 +26,28 @@ export const NicknameSection = ({
     return (
         <div>
             <div className="flex flex-row gap-2">
-                {nickname &&
-                    isNicknameChecked &&
-                    (isNicknameValid ? (
-                        <div className="flex items-center h-6 text-[12px] text-green-500 md:text-base">
-                            ✔ 사용 가능한 닉네임입니다.
-                        </div>
-                    ) : (
-                        <div className="flex items-center h-6 text-[12px] text-red-500 md:text-base">
-                            ✖ 이미 사용 중인 닉네임입니다.
-                        </div>
-                    ))}
+                <div className="w-full">
+                    {nickname &&
+                        isNicknameChecked &&
+                        (isNicknameValid ? (
+                            <div className="flex items-center h-6 text-[12px] text-green-500 md:text-base">
+                                ✔ 사용 가능한 닉네임입니다.
+                            </div>
+                        ) : (
+                            <div className="flex items-center h-6 text-[12px] text-red-500 md:text-base">
+                                ✖ 이미 사용 중인 닉네임입니다.
+                            </div>
+                        ))}
+                </div>
             </div>
 
             <div className="flex flex-row items-end align-middle gap-2 w-full">
-                <NicknameInput
-                    onValueChange={onNicknameChange}
-                    onKeyDown={handleNicknameKeyDown}
-                />
+                <div className="w-full">
+                    <NicknameInput
+                        onValueChange={onNicknameChange}
+                        onKeyDown={handleNicknameKeyDown}
+                    />
+                </div>
                 <button
                     type="button"
                     className="border border-blue-500 h-8 px-3 rounded text-blue-500 hover:bg-blue-500 hover:text-white transition-colors whitespace-nowrap"

--- a/src/constants/authInputValidation.ts
+++ b/src/constants/authInputValidation.ts
@@ -1,7 +1,7 @@
 export const AUTH_INPUT_VALIDATION = {
     nickname: {
-        regexp: /^[a-zA-Z0-9가-힣]{1,8}$/,
-        errorMessage: '✖ 8자 이내의 한글, 영문, 숫자'
+        regexp: /^[a-zA-Z0-9가-힣][a-zA-Z0-9가-힣 ]{0,9}$/,
+        errorMessage: '✖ 1~10자의 한글, 영문, 숫자 (띄어쓰기 가능)'
     },
     password: {
         regexp: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/,
@@ -12,7 +12,7 @@ export const AUTH_INPUT_VALIDATION = {
         errorMessage: '✖ 잘못된 형식입니다.'
     },
     emailVerifyCode: {
-        regexp: /^[A-Za-z0-9]{6}$/,
+        regexp: /^[A-Za-z0-9]{8}$/,
         errorMessage: '✖ 잘못된 형식입니다.'
     }
 };

--- a/src/service/auth/checkNickname.ts
+++ b/src/service/auth/checkNickname.ts
@@ -1,16 +1,6 @@
 import { AxiosError } from 'axios';
 import { defaultApi } from '@/service/api';
-import { ApiResponseType } from '@/types/apiResponse';
-
-type checkNicknameProps = {
-    nickname: string;
-};
-
-type checkNicknameResponseDataType = {
-    isDuplicated: boolean;
-};
-
-type checkNicknameResponse = ApiResponseType<checkNicknameResponseDataType>;
+import { checkNicknameProps, checkNicknameResponse } from '@/types/register';
 
 export async function checkNickname({
     nickname

--- a/src/service/auth/checkNickname.ts
+++ b/src/service/auth/checkNickname.ts
@@ -1,13 +1,13 @@
 import { AxiosError } from 'axios';
 import { defaultApi } from '@/service/api';
-import { checkNicknameProps, checkNicknameResponse } from '@/types/register';
+import { CheckNicknameProps, CheckNicknameResponse } from '@/types/register';
 
 export async function checkNickname({
     nickname
-}: checkNicknameProps): Promise<checkNicknameResponse> {
+}: CheckNicknameProps): Promise<CheckNicknameResponse> {
     const api = defaultApi();
     try {
-        const response = await api.post('/auth/duplicate-check/nickname', {
+        const response = await api.post('/user/duplicate-check/nickname', {
             nickname
         });
         return response.data;

--- a/src/service/auth/register.ts
+++ b/src/service/auth/register.ts
@@ -22,7 +22,7 @@ export async function register({
     const api = defaultApi();
 
     try {
-        const response = await api.post('/auth/signup', {
+        const response = await api.post('/user/signup', {
             email,
             password,
             nickname

--- a/src/service/auth/sendEmail.ts
+++ b/src/service/auth/sendEmail.ts
@@ -1,12 +1,6 @@
 import { AxiosError } from 'axios';
 import { defaultApi } from '@/service/api';
-import { ApiResponseType } from '@/types/apiResponse';
-
-type SendEmailProps = {
-    email: string;
-};
-
-type SendEmailResponse = ApiResponseType<'success' | 'fail'>;
+import { SendEmailProps, SendEmailResponse } from '@/types/register';
 
 export async function sendEmail({
     email
@@ -14,16 +8,20 @@ export async function sendEmail({
     const api = defaultApi();
 
     try {
-        const response = await api.post('/auth/email/send-email', { email });
+        const response = await api.post('/user/email/send', { email });
         return response.data;
     } catch (error) {
-        if (error instanceof AxiosError && error.response?.data) {
-            throw error.response.data;
+        if (error instanceof AxiosError) {
+            throw {
+                message: '서버와의 통신에 실패했습니다',
+                statusCode: 500,
+                code: 'INTERNAL_SERVER_ERROR'
+            };
         }
         throw {
-            code: 500,
-            status: 'INTERNAL_SERVER_ERROR',
-            message: '서버와의 통신에 실패했습니다.'
+            message: '알 수 없는 오류가 발생했습니다.',
+            statusCode: 500,
+            code: 'UNKNOWN_ERROR'
         };
     }
 }

--- a/src/service/auth/verifyEmail.ts
+++ b/src/service/auth/verifyEmail.ts
@@ -1,13 +1,6 @@
 import { AxiosError } from 'axios';
 import { defaultApi } from '@/service/api';
-import { ApiResponseType } from '@/types/apiResponse';
-
-type VerifyEmailProps = {
-    email: string;
-    authNum: string;
-};
-
-type VerifyEmailResponse = ApiResponseType<'success' | 'fail'>;
+import { VerifyEmailProps, VerifyEmailResponse } from '@/types/register';
 
 export async function verifyEmail({
     email,
@@ -15,7 +8,7 @@ export async function verifyEmail({
 }: VerifyEmailProps): Promise<VerifyEmailResponse> {
     const api = defaultApi();
     try {
-        const response = await api.post('/auth/email/verify', {
+        const response = await api.post('/user/email/verify', {
             email,
             authNum
         });

--- a/src/types/apiResponse.ts
+++ b/src/types/apiResponse.ts
@@ -1,6 +1,6 @@
 export interface ApiResponseType<T> {
     code: string;
-    status: string;
+    isSuccess: string;
     message: string;
     result: T;
 }

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -13,13 +13,12 @@ export type VerifyEmailProps = {
 
 export type VerifyEmailResponse = ApiResponseType<null>;
 
-export type checkNicknameProps = {
+export type CheckNicknameProps = {
     nickname: string;
 };
 
-export type checkNicknameResponseDataType = {
+export type CheckNicknameResponseDataType = {
     isDuplicated: boolean;
 };
 
-export type checkNicknameResponse =
-    ApiResponseType<checkNicknameResponseDataType>;
+export type CheckNicknameResponse = ApiResponseType<null>;

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,0 +1,25 @@
+import { ApiResponseType } from './apiResponse';
+
+export type SendEmailProps = {
+    email: string;
+};
+
+export type SendEmailResponse = ApiResponseType<string>;
+
+export type VerifyEmailProps = {
+    email: string;
+    authNum: string;
+};
+
+export type VerifyEmailResponse = ApiResponseType<null>;
+
+export type checkNicknameProps = {
+    nickname: string;
+};
+
+export type checkNicknameResponseDataType = {
+    isDuplicated: boolean;
+};
+
+export type checkNicknameResponse =
+    ApiResponseType<checkNicknameResponseDataType>;


### PR DESCRIPTION
# 🚀요약
회원가입 페이지 수정

# 📸사진 (구현 캡처)

# 📝작업 내용

-   [x] 변경된 엔드포인트로 api 경로 수정
-   [x] useRegisterForm 내부에서 이메일 인증/닉네임 중복체크 함수 내부 로직 분리함
- [x] 에러 처리 변경

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
TODO
code가 여러가지 에러를 같이 나타내고 있어서 확인 후 분기조건을 수정해야 할 것 같습니다
![image](https://github.com/user-attachments/assets/4beb0a18-3f3d-4dd9-ae14-29183fe94293)
![image](https://github.com/user-attachments/assets/953dd225-3f1a-4831-9a0f-60b9d71dee34)

close #218 
