### PR TITLE
feat : 키워드 편지 상세 조회 api 연동

### DIFF
--- a/src/components/LetterDetailPage/KeywordLetterDetail.tsx
+++ b/src/components/LetterDetailPage/KeywordLetterDetail.tsx
@@ -1,67 +1,82 @@
+import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
-
-type KeywordLetterDetailProps = {
-    content: string;
-    keywords: string[];
-    date: string;
-};
-
-export const KeywordLetterDetail = ({
-    content,
-    keywords,
-    date
-}: KeywordLetterDetailProps) => {
+import { useKeywordLetterDetail } from '@/hooks/useGetKeywordLetterDetail';
+import { formatDate } from '@/util/formatDate';
+export const KeywordLetterDetail = () => {
+    const { letterId } = useParams<{ letterId: string }>();
     const [isOpen, setIsOpen] = useState(false);
+
+    const { data, isLoading, error } = useKeywordLetterDetail({
+        letterId: letterId || ''
+    });
 
     const onClick = () => {
         setIsOpen((prev) => !prev);
     };
 
-    return (
-        <>
-            <p className="absolute left-24 top-[19rem]">{content}</p>
-            <div className="absolute bottom-16 w-[580px] h-[100px]">
-                <p className="font-bold m-4">편지의 키워드</p>
-                <div className="m-4">
-                    <p
-                        className={`flex flex-wrap ${
-                            isOpen ? '' : 'max-w-[550px] overflow-hidden'
-                        }`}
-                    >
-                        {keywords
-                            .slice(0, isOpen ? keywords.length : 4)
-                            .map((keyword, index) => (
-                                <span
-                                    key={index}
-                                    className="mr-2 mb-2 keyword-tag"
+    if (isLoading) {
+        return <div>Loading...</div>;
+    }
+
+    if (error instanceof Error) {
+        console.error('error:', error.message);
+        return <div>Error: {error.message}</div>;
+    }
+
+    if (data) {
+        const { title, content, keywords, createdAt } = data;
+
+        return (
+            <>
+                <p className="absolute left-24 top-[15rem]">{title}</p>
+                <p className="absolute left-24 top-[19rem]">{content}</p>
+                <div className="absolute bottom-16 w-[580px] h-[100px]">
+                    {keywords.length > 0 && (
+                        <>
+                            <p className="font-bold m-4">편지의 키워드</p>
+                            <div className="m-4">
+                                <p
+                                    className={`flex flex-wrap ${isOpen ? '' : 'max-w-[550px] overflow-hidden'}`}
                                 >
-                                    {keyword}
-                                </span>
-                            ))}
-                        {!isOpen && keywords.length > 4 && (
-                            <button
-                                className="flex items-center "
-                                onClick={onClick}
-                            >
-                                <span className="text-4xl">...</span>
-                                <IoIosArrowDown className="text-3xl mr-2" />
-                            </button>
-                        )}
-                        {isOpen && keywords.length > 4 && (
-                            <button
-                                className="flex items-center "
-                                onClick={onClick}
-                            >
-                                <IoIosArrowUp className="text-3xl mr-2" />
-                            </button>
-                        )}
-                    </p>
+                                    {keywords
+                                        .slice(0, isOpen ? keywords.length : 4)
+                                        .map((keyword, index) => (
+                                            <span
+                                                key={index}
+                                                className="mr-2 mb-2 keyword-tag"
+                                            >
+                                                {keyword}
+                                            </span>
+                                        ))}
+                                    {!isOpen && keywords.length > 4 && (
+                                        <button
+                                            className="flex items-center"
+                                            onClick={onClick}
+                                        >
+                                            <span className="text-4xl">
+                                                ...
+                                            </span>
+                                            <IoIosArrowDown className="text-3xl mr-2" />
+                                        </button>
+                                    )}
+                                    {isOpen && keywords.length > 4 && (
+                                        <button
+                                            className="flex items-center"
+                                            onClick={onClick}
+                                        >
+                                            <IoIosArrowUp className="text-3xl mr-2" />
+                                        </button>
+                                    )}
+                                </p>
+                            </div>
+                        </>
+                    )}
                 </div>
-            </div>
-            <div className="absolute bottom-8 translate-x-60 flex-col">
-                <p className="ml-2">{date}</p>
-            </div>
-        </>
-    );
+                <div className="absolute bottom-8 translate-x-60 flex-col">
+                    <p className="ml-2">{formatDate(createdAt)}</p>
+                </div>
+            </>
+        );
+    }
 };

--- a/src/hooks/useGetKeywordLetterDetail.ts
+++ b/src/hooks/useGetKeywordLetterDetail.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { getKeywordLetterDetail } from '@/service/detail/getKeywordLetterDetail';
+import { GetKeywordLetterDetailResponseType } from '@/types/letter';
+
+type UseKeywordLetterDetailProps = {
+    letterId: string;
+};
+
+export const useKeywordLetterDetail = ({
+    letterId
+}: UseKeywordLetterDetailProps) => {
+    return useQuery<GetKeywordLetterDetailResponseType, Error>({
+        queryKey: ['keywordLetterDetail', letterId],
+        queryFn: async () => {
+            const response = await getKeywordLetterDetail({ letterId });
+            return response.result;
+        },
+        enabled: !!letterId
+    });
+};

--- a/src/pages/Letter/Detail/LetterDetailPage.tsx
+++ b/src/pages/Letter/Detail/LetterDetailPage.tsx
@@ -28,16 +28,6 @@ export const LetterDetailPage = ({
         name: '이미지',
         src: '/라벨_샘플.png'
     };
-    const sampleKeywords = [
-        '키워드',
-        '베리 롱 롱 키워드',
-        '베리 롱 키워드',
-        '키워드',
-        '키워드',
-        '베리 롱 키워드',
-        '키워드',
-        '키워드'
-    ];
 
     const sampleReplies = [
         { id: 1, title: '답장 제목 1', date: '24.11.28' },
@@ -82,11 +72,7 @@ export const LetterDetailPage = ({
                             hint="서대문역 앞 붕어빵 가게에서"
                         />
                     ) : (
-                        <KeywordLetterDetail
-                            content="편지내용"
-                            keywords={sampleKeywords}
-                            date="24.11.18"
-                        />
+                        <KeywordLetterDetail />
                     )}
                 </div>
             </div>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -103,7 +103,7 @@ export const router = createBrowserRouter([
         element: <RegisterPage />
     },
     {
-        path: '/letter/:type/:id',
+        path: '/letter/:type/:letterId',
         element: <LetterDetailPage />
     },
     {

--- a/src/service/detail/getKeywordLetterDetail.ts
+++ b/src/service/detail/getKeywordLetterDetail.ts
@@ -1,0 +1,22 @@
+import { defaultApi } from '@/service/api';
+import { ApiResponseType } from '@/types/apiResponse';
+import { GetKeywordLetterDetailResponseType } from '@/types/letter';
+
+type KeywordLetterDetailRequestProps = {
+    letterId: string;
+};
+
+type KeywordLetterDetailResponse =
+    ApiResponseType<GetKeywordLetterDetailResponseType>;
+
+export async function getKeywordLetterDetail({
+    letterId
+}: KeywordLetterDetailRequestProps): Promise<KeywordLetterDetailResponse> {
+    const api = defaultApi();
+
+    const response = await api.get<KeywordLetterDetailResponse>(
+        `/letters/detail/${letterId}`
+    );
+
+    return response.data;
+}

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -23,3 +23,16 @@ export type CreateLetterResponseType = {
         createdAt: string;
     };
 };
+
+export type GetKeywordLetterDetailResponseType = {
+    letterId: number;
+    title: string;
+    content: string;
+    keywords: string[];
+    font: string;
+    paper: string;
+    profile: string;
+    label: string;
+    isOwner: boolean;
+    createdAt: string;
+};

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -1,0 +1,7 @@
+export const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    const year = date.getFullYear().toString().slice(-2);
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}.${month}.${day}`;
+};


### PR DESCRIPTION
# 🚀요약
키워드 편지 상세 조회 api 연동
# 📸사진 (구현 캡처)
![image](https://github.com/user-attachments/assets/7d4be073-926e-49e8-8859-c1dfb37ada99)
- 키워드 선택 안 한 편지
# 📝작업 내용

-   [x] 키워드 편지 상세 조회 api 연동

# 🎸기타 (연관 이슈)
- 성공 로직만 작성하여 전역 에러 핸들러로 에러 처리
- 편지의 lineheight는 추후 처리 예정
- 상세보기 페이지에서 삭제, 신고, 보관 기능은 추가 예정

close #262
