### PR TITLE
253 feat 지도 편지 페이지 주변 편지 조회 api 연동

### DIFF
--- a/src/components/MapPage/LetterInfoContainer/LetterInfoContainer.tsx
+++ b/src/components/MapPage/LetterInfoContainer/LetterInfoContainer.tsx
@@ -5,7 +5,7 @@ import { NavLink } from 'react-router-dom';
 interface LetterInfoContainerProps {
     id: number;
     title: string;
-    distance: number;
+    distance: string;
     date: string;
     daysLeft: number;
 }

--- a/src/components/MapPage/Maplibre/MaplibreWithSearch.tsx
+++ b/src/components/MapPage/Maplibre/MaplibreWithSearch.tsx
@@ -11,44 +11,11 @@ import { LuMapPin } from 'react-icons/lu';
 import { useSearchStore } from '@/stores/useSearchStore';
 import { useCurrentLocation } from '@/hooks/useCurrentLocation';
 import { useNearbyLetters } from '@/hooks/useNearbyLetters';
+import { NearbyLettersResponseType } from '@/types/letter';
 
-type Letter = {
-    id: number;
-    longitude: number;
-    latitude: number;
-    title: string;
-    keyword: string;
-    date: string;
-};
 type MaplibreWithSearchProps = {
     onFocus: () => void;
 };
-const sampleLetters: Letter[] = [
-    {
-        id: 1,
-        longitude: 127.01,
-        latitude: 37.51,
-        title: '첫 번째 편지',
-        keyword: '가을 바람',
-        date: '21.11.15'
-    },
-    {
-        id: 2,
-        longitude: 127.02,
-        latitude: 37.52,
-        title: '두 번째 편지',
-        keyword: '단풍',
-        date: '21.11.20'
-    },
-    {
-        id: 3,
-        longitude: 126.99,
-        latitude: 37.49,
-        title: '세 번째 편지',
-        keyword: '바람',
-        date: '21.11.25'
-    }
-];
 
 export const MaplibreWithSearch = ({ onFocus }: MaplibreWithSearchProps) => {
     const { toggleSelectedLetter, clearSelectedLetter } =
@@ -62,8 +29,8 @@ export const MaplibreWithSearch = ({ onFocus }: MaplibreWithSearchProps) => {
         latitude: 37.5,
         zoom: 11
     });
+    const { nearbyLetters } = useNearbyLetters(currentLocation);
 
-    const nearbyLetters = useNearbyLetters(currentLocation, sampleLetters);
     useEffect(() => {
         if (searchedLocation) {
             setViewState({
@@ -133,26 +100,28 @@ export const MaplibreWithSearch = ({ onFocus }: MaplibreWithSearchProps) => {
                         />
                     </Marker>
                 )}
-                {nearbyLetters.map((letter) => (
-                    <Marker
-                        key={letter.id}
-                        longitude={letter.longitude}
-                        latitude={letter.latitude}
-                    >
-                        <div
-                            className="bg-gray-100 p-1 rounded-sm"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                toggleSelectedLetter(letter);
-                            }}
+                {nearbyLetters.map(
+                    (letter: NearbyLettersResponseType['result'][0]) => (
+                        <Marker
+                            key={letter.letterId}
+                            longitude={letter.longitude}
+                            latitude={letter.latitude}
                         >
-                            <img
-                                src="/bottle.png"
-                                className="w-full h-5 rounded-lg"
-                            />
-                        </div>
-                    </Marker>
-                ))}
+                            <div
+                                className="bg-gray-100 p-1 rounded-sm"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    toggleSelectedLetter(letter);
+                                }}
+                            >
+                                <img
+                                    src="/bottle.png"
+                                    className="w-full h-5 rounded-lg"
+                                />
+                            </div>
+                        </Marker>
+                    )
+                )}
                 {searchedLocation && (
                     <Marker
                         longitude={parseFloat(searchedLocation.lon)}

--- a/src/hooks/useNearbyLetters.ts
+++ b/src/hooks/useNearbyLetters.ts
@@ -25,18 +25,31 @@ export const useNearbyLetters = (
                 return [];
             }
 
-            return response.result.map((letter) => ({
-                letterId: letter.letterId,
-                latitude: letter.latitude,
-                longitude: letter.longitude,
-                title: letter.title,
-                createdAt: letter.createdAt,
-                distance: letter.distance,
-                target: letter.target,
-                createUserNickname: letter.createUserNickname,
-                label: letter.label,
-                description: letter.description
-            }));
+            return response.result.map(
+                ({
+                    letterId,
+                    latitude,
+                    longitude,
+                    title,
+                    createdAt,
+                    distance,
+                    target,
+                    createUserNickname,
+                    label,
+                    description
+                }) => ({
+                    letterId,
+                    latitude,
+                    longitude,
+                    title,
+                    createdAt,
+                    distance,
+                    target,
+                    createUserNickname,
+                    label,
+                    description
+                })
+            );
         },
         enabled: !!currentLocation,
 

--- a/src/hooks/useNearbyLetters.ts
+++ b/src/hooks/useNearbyLetters.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { nearbyLetters } from '@/service/MapLetter/nearbyLetters';
+import { getNearbyLetters } from '@/service/MapLetter/getNearbyLetters';
 import { NearbyLettersResponseType } from '@/types/letter';
 
 export const useNearbyLetters = (
@@ -16,7 +16,7 @@ export const useNearbyLetters = (
                 return [];
             }
 
-            const response = await nearbyLetters({
+            const response = await getNearbyLetters({
                 latitude: currentLocation.latitude.toString(),
                 longitude: currentLocation.longitude.toString()
             });

--- a/src/pages/Map/MapExplorerPage.tsx
+++ b/src/pages/Map/MapExplorerPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { LetterInfoContainer } from '@/components/MapPage/LetterInfoContainer/LetterInfoContainer';
 import { NavigateContainer } from '@/components/MapPage/NavigateContainer/NavigateContainer';
 import { MaplibreWithSearch } from '@/components/MapPage/Maplibre/MaplibreWithSearch';
@@ -8,6 +8,9 @@ import { NavLink } from 'react-router-dom';
 import { SearchFullScreen } from '@/components/MapPage/SearchFullScreen/SearchFullScreen';
 import useNominatimSearch from '@/hooks/useNominatimSearch';
 import { useSearchStore } from '@/stores/useSearchStore';
+import { formatDate } from '@/util/formatDate';
+import { calculateDaysLeft } from '@/util/calculateDaysLeft';
+import { formatDistance } from '@/util/formatDistance';
 
 export const MapExplorerPage = () => {
     const { searchedLocation } = useSearchStore();
@@ -19,6 +22,19 @@ export const MapExplorerPage = () => {
     const [isOpen, setIsOpen] = useState(false);
     const [query, setQuery] = useState('');
     const { error, data, isLoading } = useNominatimSearch(query);
+
+    const [daysLeft, setDaysLeft] = useState(0);
+
+    useEffect(() => {
+        if (selectedLetter) {
+            const days = calculateDaysLeft(selectedLetter.createdAt);
+            setDaysLeft(days);
+        }
+    }, [selectedLetter]);
+
+    const formattedDistance = selectedLetter
+        ? formatDistance(selectedLetter.distance)
+        : '0.0';
 
     const onFocus = () => {
         setIsSearchFocused(true);
@@ -76,11 +92,11 @@ export const MapExplorerPage = () => {
                                     </NavLink>
                                 )}
                                 <LetterInfoContainer
-                                    id={123}
-                                    title="익명 편지"
-                                    distance={400}
-                                    date="21.11.15"
-                                    daysLeft={21}
+                                    id={selectedLetter.letterId}
+                                    title={selectedLetter.title}
+                                    distance={`${formattedDistance}`}
+                                    date={formatDate(selectedLetter.createdAt)}
+                                    daysLeft={daysLeft}
                                 />
                             </>
                         ) : (

--- a/src/service/MapLetter/getNearbyLetters.ts
+++ b/src/service/MapLetter/getNearbyLetters.ts
@@ -9,7 +9,7 @@ type NearbyLettersRequestProps = {
 
 type NearbyLettersResponse = ApiResponseType<NearbyLettersResponseType>;
 
-export async function nearbyLetters({
+export async function getNearbyLetters({
     latitude,
     longitude
 }: NearbyLettersRequestProps): Promise<NearbyLettersResponse> {

--- a/src/service/MapLetter/nearbyLetters.ts
+++ b/src/service/MapLetter/nearbyLetters.ts
@@ -1,0 +1,33 @@
+import { defaultApi } from '@/service/api';
+import { ApiResponseType } from '@/types/apiResponse';
+import { NearbyLettersResponseType } from '@/types/letter';
+
+type NearbyLettersRequestProps = {
+    latitude: string;
+    longitude: string;
+};
+
+type NearbyLettersResponse = ApiResponseType<NearbyLettersResponseType>;
+
+export async function nearbyLetters({
+    latitude,
+    longitude
+}: NearbyLettersRequestProps): Promise<NearbyLettersResponse> {
+    const api = defaultApi();
+    try {
+        const response = await api.get<NearbyLettersResponse>(`/map`, {
+            params: { latitude, longitude }
+        });
+        console.log('Response data:', response.data);
+        if (!response.data.isSuccess) {
+            throw new Error(
+                response.data.message || 'Failed to fetch nearby letters'
+            );
+        }
+
+        return response.data;
+    } catch (error) {
+        console.error('Error fetching nearby letters:', error);
+        throw error;
+    }
+}

--- a/src/service/MapLetter/nearbyLetters.ts
+++ b/src/service/MapLetter/nearbyLetters.ts
@@ -14,20 +14,8 @@ export async function nearbyLetters({
     longitude
 }: NearbyLettersRequestProps): Promise<NearbyLettersResponse> {
     const api = defaultApi();
-    try {
-        const response = await api.get<NearbyLettersResponse>(`/map`, {
-            params: { latitude, longitude }
-        });
-        console.log('Response data:', response.data);
-        if (!response.data.isSuccess) {
-            throw new Error(
-                response.data.message || 'Failed to fetch nearby letters'
-            );
-        }
-
-        return response.data;
-    } catch (error) {
-        console.error('Error fetching nearby letters:', error);
-        throw error;
-    }
+    const response = await api.get<NearbyLettersResponse>(`/map`, {
+        params: { latitude, longitude }
+    });
+    return response.data;
 }

--- a/src/stores/useSelectedLetterStore.tsx
+++ b/src/stores/useSelectedLetterStore.tsx
@@ -1,12 +1,16 @@
 import { create } from 'zustand';
 
 type Letter = {
-    id: number;
-    longitude: number;
+    letterId: number;
     latitude: number;
+    longitude: number;
     title: string;
-    keyword: string;
-    date: string;
+    createdAt: string;
+    distance: number;
+    target: number;
+    createUserNickname: string;
+    label: string;
+    description: string;
 };
 
 type SelectedLetter = {
@@ -21,7 +25,7 @@ export const useSelectedLetterStore = create<SelectedLetter>((set) => ({
     setSelectedLetter: (letter) => set({ selectedLetter: letter }),
     toggleSelectedLetter: (letter) =>
         set((state) =>
-            state.selectedLetter?.id === letter.id
+            state.selectedLetter?.letterId === letter.letterId
                 ? { selectedLetter: null }
                 : { selectedLetter: letter }
         ),

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -23,3 +23,21 @@ export type CreateLetterResponseType = {
         createdAt: string;
     };
 };
+
+export type NearbyLettersResponseType = {
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: {
+        letterId: number;
+        latitude: number;
+        longitude: number;
+        title: string;
+        createdAt: string;
+        distance: number;
+        target: number;
+        createUserNickname: string;
+        label: string;
+        description: string;
+    }[];
+};

--- a/src/util/calculateDaysLeft.ts
+++ b/src/util/calculateDaysLeft.ts
@@ -1,0 +1,7 @@
+export const calculateDaysLeft = (writtenDate: string): number => {
+    const currentDate = new Date();
+    const letterDate = new Date(writtenDate);
+    const timeDiff = currentDate.getTime() - letterDate.getTime();
+    const daysDiff = Math.floor(timeDiff / (1000 * 3600 * 24));
+    return 30 - daysDiff;
+};

--- a/src/util/formatDistance.ts
+++ b/src/util/formatDistance.ts
@@ -1,0 +1,3 @@
+export const formatDistance = (distance: number): string => {
+    return distance.toFixed(1);
+};


### PR DESCRIPTION
# 🚀요약
지도 편지 페이지 주변 편지 조회 api 연동
# 📸사진 (구현 캡처)
![image](https://github.com/user-attachments/assets/429297bc-b2fd-4b45-8147-beabfb3fb81e)
![image](https://github.com/user-attachments/assets/033b1e78-e3cf-4927-8c1b-8a0dfb846c77)

# 📝작업 내용

-   [x] 지도 편지 페이지 주변 편지 조회 api 연동



# 🎸기타 (연관 이슈)
- 반경 15m 내 편지만 상세조회 api 연동 예정
- 지도 편지 상세보기 api 연동 예정
close #이슈번호
