### PR TITLE
feat : 프로필 이미지 공유 페이지 추가

### DIFF
--- a/src/components/MyPage/KeywordListSection.tsx
+++ b/src/components/MyPage/KeywordListSection.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 
 type KeywordListSectionProps = {
+    showTitle?: boolean;
     keywords: string[];
 };
 
-export const KeywordListSection = ({ keywords }: KeywordListSectionProps) => (
+export const KeywordListSection = ({
+    showTitle = true,
+    keywords
+}: KeywordListSectionProps) => (
     <div className="flex flex-col gap-2">
-        <h2 className="font-bold text-sample-black">내가 자주 쓴 키워드</h2>
+        {showTitle ? (
+            <h2 className="font-bold text-sample-black">내가 자주 쓴 키워드</h2>
+        ) : null}
         <div className="flex flex-row flex-wrap gap-3">
             {keywords.map((keyword, index) => (
                 <div key={index} className="bg-gray-100 rounded-xl px-4 py-2">

--- a/src/pages/User/MyPage/MyPage.tsx
+++ b/src/pages/User/MyPage/MyPage.tsx
@@ -2,9 +2,14 @@ import { useUserStore } from '@/stores/useUserStore';
 import { ProfileSection } from '@/components/MyPage/ProfileSection';
 import { MenuListSection } from '@/components/MyPage/MenuListSection';
 import { KeywordListSection } from '@/components/MyPage/KeywordListSection';
+import { logout } from '@/service/auth/logout';
+import { useToastStore } from '@/hooks';
+import { useNavigate } from 'react-router-dom';
 
 export const MyPage = () => {
     const { user } = useUserStore();
+    const { addToast } = useToastStore();
+    const navigate = useNavigate();
 
     const sampleKeywords = [
         '키워드',
@@ -22,13 +27,24 @@ export const MyPage = () => {
 
     const labelMenuItems = [{ content: '라벨첩', url: '/labels' }];
 
+    const handleLogout = () => {
+        addToast('로그아웃 되었습니다.', 'success');
+        logout();
+        navigate('/login');
+    };
+
     return (
         <div className="flex flex-col gap-8">
             <h1 className="font-semibold text-gray-600 text-[21px]">
                 마이페이지
             </h1>
             <div className="flex flex-col gap-10">
-                <ProfileSection user={user!} />
+                <div className="flex flex-col gap-4 justify-end">
+                    <ProfileSection user={user!} />
+                    <div className="" onClick={handleLogout}>
+                        로그아웃
+                    </div>
+                </div>
                 <MenuListSection menuItems={menuItems} />
                 <MenuListSection menuItems={labelMenuItems} />
                 <KeywordListSection keywords={sampleKeywords} />

--- a/src/pages/User/Profile/ProfileSharePage.tsx
+++ b/src/pages/User/Profile/ProfileSharePage.tsx
@@ -1,0 +1,51 @@
+import { IconMenuButton } from '@/components/MyPage/IconMenuButton';
+import { KeywordListSection } from '@/components/MyPage/KeywordListSection';
+import { useDownloadCanvas } from '@/hooks';
+import { useUserStore } from '@/stores';
+
+export const ProfileSharePage = () => {
+    const { user } = useUserStore();
+    const { captureRef, downloadCanvasAsImage } = useDownloadCanvas();
+
+    const showModal = () => {};
+
+    const handleShare = async () => {
+        await downloadCanvasAsImage();
+        showModal();
+    };
+
+    const sampleKeywords = [
+        '키워드',
+        '베리 롱 롱 키워드',
+        '베리 롱 키워드',
+        '키워드',
+        '키워드'
+    ];
+
+    return (
+        <div className="flex flex-col gap-5 items-center">
+            <h2 className="text-bold text-lg">{user?.nickname}</h2>
+            <div
+                className="flex flex-col bg-sample-blue rounded-md p-4 gap-3 w-[290px] items-center"
+                ref={captureRef}
+            >
+                <div className="bg-white w-[full] rounded-md">
+                    <img
+                        src={user?.profileImageUrl}
+                        className="object-contain p-5"
+                        crossOrigin="anonymous"
+                    />
+                </div>
+                <KeywordListSection
+                    keywords={sampleKeywords}
+                    showTitle={false}
+                />
+            </div>
+            <IconMenuButton
+                onClick={handleShare}
+                iconUrl="/ic_share.svg"
+                content="공유하기"
+            />
+        </div>
+    );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { LetterDetailPage } from '@/pages/Letter/Detail/LetterDetailPage';
 import { NotificationPage } from '@/pages/Notification/NotificationPage';
 import { ReplyLetterDetailPage } from '@/pages/Letter/Detail/ReplyLetterDetailPage';
 import { SentPage } from '@/pages/SentPage';
-import { SharePage } from '@/pages/SharePage';
+import { ProfileSharePage } from '@/pages/User/Profile/ProfileSharePage';
 import { LabelLotteryPage } from './Label/Lottery/LabelLotteryPage';
 import { SelectItemPage } from './Letter/SelectItem/SelectItemPage';
 import { MyPage } from '@/pages/User/MyPage/MyPage';
@@ -32,7 +32,7 @@ export {
     ReplyLetterDetailPage,
     NotificationPage,
     SentPage,
-    SharePage,
+    ProfileSharePage,
     LabelLotteryPage,
     SelectItemPage,
     SuccessLetterPage,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -14,14 +14,13 @@ import {
     ReplyLetterDetailPage,
     NotificationPage,
     SentPage,
-    SharePage,
+    ProfileSharePage,
     LabelLotteryPage,
     SelectItemPage,
     SuccessLetterPage,
     ProfilePage,
     StoragePage
 } from './pages';
-import { Margin } from './components/Common/Margin/Margin';
 import { tokenStorage } from './service/auth/tokenStorage';
 import { AuthProvider } from './AuthProvider';
 import { Container } from '@/components/Common/Container/Container';
@@ -112,8 +111,8 @@ export const router = createBrowserRouter([
                 element: <SentPage />
             },
             {
-                path: '/share',
-                element: <SharePage />
+                path: '/profileshare',
+                element: <ProfileSharePage />
             },
             {
                 path: '/letter/:type/reply/:replyLetterId',


### PR DESCRIPTION
# 🚀요약
프로필 이미지 공유 페이지 추가

# 📸사진 (구현 캡처)
![image](https://github.com/user-attachments/assets/9b53b409-12e4-47cd-bcfc-ab0c9b4c1a95)


# 📝작업 내용

-   [x] 프로필 이미지 공유 페이지 레이아웃 작성
- [x] 훅 연결 

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
완료 모달 추가 고려

close #303 
