### PR TITLE
 feat : 지도 편지 주변 편지 상세보기 페이지 보관 api 연동

### DIFF
--- a/src/hooks/usePostNearByLetterStorage.ts
+++ b/src/hooks/usePostNearByLetterStorage.ts
@@ -1,0 +1,11 @@
+import { postNearByLetterStorage } from '@/service/MapLetter/postNearbyLettersStorage';
+import { ApiResponseType } from '@/types/apiResponse';
+import { useMutation } from '@tanstack/react-query';
+
+export const usePostNearByLetterStorage = (letterId: number) => {
+    return useMutation<ApiResponseType<string>, Error, void>({
+        mutationFn: async () => {
+            return await postNearByLetterStorage({ letterId });
+        }
+    });
+};

--- a/src/service/MapLetter/getNearByLetterDetail.ts
+++ b/src/service/MapLetter/getNearByLetterDetail.ts
@@ -19,6 +19,5 @@ export async function getNearByLetterDetail({
     const response = await api.get<NearbyLettersResponse>(`/map/${letterId}`, {
         params: { latitude, longitude }
     });
-    console.log(response.data);
     return response.data;
 }

--- a/src/service/MapLetter/postNearbyLettersStorage.ts
+++ b/src/service/MapLetter/postNearbyLettersStorage.ts
@@ -1,0 +1,18 @@
+import { defaultApi } from '@/service/api';
+import { ApiResponseType } from '@/types/apiResponse';
+
+type postNearByLetterStorageRequestProps = {
+    letterId: number;
+};
+
+type postNearByLetterStorageResponse = ApiResponseType<string>;
+
+export async function postNearByLetterStorage({
+    letterId
+}: postNearByLetterStorageRequestProps): Promise<postNearByLetterStorageResponse> {
+    const api = defaultApi();
+    const response = await api.post<postNearByLetterStorageResponse>(
+        `/map/${letterId}`
+    );
+    return response.data;
+}


### PR DESCRIPTION
# 🚀요약
지도 편지 주변 편지 상세보기 페이지 보관 api 연동
# 📸사진 (구
![Animation777](https://github.com/user-attachments/assets/50b8df49-8be2-4ffa-b297-d63c7581668d)
현 캡처)

# 📝작업 내용

-   [x] 지도 편지 주변 편지 상세보기 페이지 보관 api 연동
## 🔍백엔드 전달 사항
지도 편지 보관 API 이미 저장되어 있는지 필요 
# 🎸기타 (연관 이슈)
API에 저장되어 있는지 2번 확인해야 해서 이렇게 했습니다...!
보관했으면 보관됨이라고 변경했는데 어떻게 바꿀까요?
close #326
