### PR TITLE
refactor : 보관함 리팩토링

### DIFF
--- a/src/components/StoragePage/LetterDateGroup.tsx
+++ b/src/components/StoragePage/LetterDateGroup.tsx
@@ -1,0 +1,46 @@
+import { LetterListItem } from './LetterListItem';
+import { DeleteLetterType } from '@/types/letter';
+
+interface Letter {
+    letterId: number;
+    title: string;
+    label: string;
+    letterType: string;
+    boxType: string;
+    createdAt: string;
+}
+
+type LetterDateGroupProps = {
+    date: string;
+    letters: Letter[];
+    checkedItems: DeleteLetterType[];
+    handleSingleCheck: (
+        checked: boolean,
+        { letterId, letterType, boxType }: DeleteLetterType
+    ) => void;
+};
+
+export const LetterDateGroup = ({
+    date,
+    letters,
+    checkedItems,
+    handleSingleCheck
+}: LetterDateGroupProps) => {
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="font-medium text-md">{date}</div>
+            <div className="flex flex-col gap-2">
+                {letters.map((letter) => (
+                    <LetterListItem
+                        key={letter.letterId}
+                        letter={letter}
+                        checked={checkedItems.some(
+                            (item) => item.letterId === letter.letterId
+                        )}
+                        handleSingleCheck={handleSingleCheck}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/components/StoragePage/LetterListItem.tsx
+++ b/src/components/StoragePage/LetterListItem.tsx
@@ -1,0 +1,96 @@
+import { Itembox } from '@/components/Common/Itembox/Itembox';
+import { BottleLetter } from '@/components/Common/BottleLetter/BottleLetter';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { DeleteLetterType, storageLetterType } from '@/types/letter';
+import { match } from 'ts-pattern';
+
+interface Letter {
+    letterId: number;
+    title: string;
+    label: string;
+    letterType: string;
+    boxType: string;
+    createdAt: string;
+}
+
+type LetterListItemProps = {
+    letter: Letter;
+    checked: boolean;
+    handleSingleCheck: (
+        checked: boolean,
+        { letterId, letterType, boxType }: DeleteLetterType
+    ) => void;
+};
+
+export const LetterListItem = ({
+    letter,
+    checked,
+    handleSingleCheck
+}: LetterListItemProps) => {
+    const navigate = useNavigate();
+
+    const { letterType } = useParams();
+    const [searchParams] = useSearchParams();
+    const filterType = searchParams.get('filtertype');
+
+    const renderCategory = (boxType: string, letterType: string) => {
+        const condition = `${boxType}-${letterType}`;
+        switch (condition) {
+            case 'SEND-LETTER':
+                return '보낸 편지';
+            case 'SEND-REPLY_LETTER':
+                return '보낸 답장';
+            case 'RECEIVE-LETTER':
+                return '받은 편지';
+            case 'RECEIVE-REPLY_LETTER':
+                return '받은 답장';
+            default:
+        }
+    };
+
+    const getNavigatePath = (letter: Letter) => {
+        return match<storageLetterType>(letterType as storageLetterType)
+            .with(
+                'keyword',
+                () =>
+                    `/letter/keyword/${letter.letterType}/${filterType}/${letter.letterId}`
+            )
+            .with('map', () => `/letter/map/${filterType}/${letter.letterId}`)
+            .with(
+                'bookmark',
+                () => `/letter/map/${filterType}/bookmark/${letter.letterId}`
+            )
+            .exhaustive();
+    };
+
+    return (
+        <div key={letter.letterId} className="flex flex-row gap-2">
+            <input
+                type="checkbox"
+                name={`select-${letter.letterId}`}
+                onChange={(e) =>
+                    handleSingleCheck(e.target.checked, {
+                        letterId: letter.letterId,
+                        letterType: letter.letterType,
+                        boxType: letter.boxType
+                    })
+                }
+                checked={checked}
+            />
+            <div
+                className="flex flex-row gap-4 w-full h-[90px] items-center p-4 rounded-lg bg-sample-gray cursor-pointer"
+                onClick={() => navigate(getNavigatePath(letter))}
+            >
+                <Itembox>
+                    <BottleLetter Letter={letter} />
+                </Itembox>
+                <div className="flex flex-col h-full">
+                    <div className="text-[12px] text-gray-500 mt-2">
+                        {renderCategory(letter.boxType, letter.letterType)}
+                    </div>
+                    <h3 className="text-sm font-bold">{letter.title}</h3>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/hooks/useInfiniteStorageFetch.ts
+++ b/src/hooks/useInfiniteStorageFetch.ts
@@ -11,22 +11,30 @@ interface Letter {
     createdAt: string;
 }
 
-export const useInfiniteStorageFetch = (apiEndpoint: string, size: number) => {
+type useInfiniteStorageFetchParams = {
+    apiEndpoint: string;
+    size: number;
+};
+
+export const useInfiniteStorageFetch = ({
+    apiEndpoint,
+    size
+}: useInfiniteStorageFetchParams) => {
     const getLetterList = async ({ pageParam }: { pageParam: number }) => {
         console.log(`API 호출: page ${pageParam}, size ${size}`);
         const page = pageParam;
         const response = await getLetter({ apiEndpoint, page, size });
-
+        console.log('데이터:', response.result);
         return response.result;
     };
 
     const {
         data,
-        isLoading,
         isError,
+        status,
         fetchNextPage,
-        isFetching,
-        isFetchingNextPage
+        isFetchingNextPage,
+        hasNextPage
     } = useInfiniteQuery({
         queryKey: ['storageLetters', apiEndpoint],
         queryFn: getLetterList,
@@ -55,13 +63,7 @@ export const useInfiniteStorageFetch = (apiEndpoint: string, size: number) => {
             console.log('데이터없음');
             return [];
         }
-        console.log('isLoading:', isLoading);
-        console.log('isFetching:', isFetching);
-        console.log('error:', isError);
-
         const allLetters = data.pages.flatMap((page) => page.content);
-        console.log(allLetters);
-
         const grouped = allLetters.reduce(
             (acc: { [key: string]: Letter[] }, letter) => {
                 const date = new Date(letter.createdAt)
@@ -94,10 +96,10 @@ export const useInfiniteStorageFetch = (apiEndpoint: string, size: number) => {
 
     return {
         groupedLetters,
-        isLoading,
+        status,
         isError,
         fetchNextPage,
-        isFetching,
-        isFetchingNextPage
+        isFetchingNextPage,
+        hasNextPage
     };
 };

--- a/src/pages/Storage/StoragePage.tsx
+++ b/src/pages/Storage/StoragePage.tsx
@@ -1,14 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import { StorageList } from '@/components/StoragePage/StorageList';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
-type storageType = 'keyword' | 'map' | 'bookmark';
+type LetterType = 'keyword' | 'map' | 'bookmark';
 
-interface StoragePageProps {
-    initialType?: storageType;
-}
-
-const getTranslateX = (path: storageType) => {
+const getTranslateX = (path: LetterType) => {
     const pathIndex =
         {
             keyword: 0,
@@ -19,16 +15,24 @@ const getTranslateX = (path: storageType) => {
     return `${pathIndex * 100}%`;
 };
 
-export const StoragePage = ({ initialType }: StoragePageProps) => {
+export const StoragePage = () => {
+    const navigate = useNavigate();
+    const { letterType } = useParams();
     const [searchParams, setSearchParams] = useSearchParams();
-    const [storageType, setStorageType] = useState<storageType>(
-        (searchParams.get('type') as storageType) || initialType || 'keyword'
-    );
 
-    const handleTypeChange = (type: storageType) => {
-        setStorageType(type);
-        setSearchParams({ type });
+    const handleNavigate = (type: LetterType) => {
+        if (type === 'bookmark') return navigate(`/storage/${type}`);
+        navigate(`/storage/${type}?filtertype=sent`);
     };
+
+    // 마운트 될 때 초기 필터타입을 지정합니다
+    useEffect(() => {
+        if (letterType === 'bookmark') return;
+        const currentFilter = searchParams.get('filtertype');
+        if (!currentFilter) {
+            setSearchParams({ filtertype: 'sent' });
+        }
+    }, []);
 
     return (
         <div className="flex flex-col h-full">
@@ -37,24 +41,24 @@ export const StoragePage = ({ initialType }: StoragePageProps) => {
                     <div
                         className="absolute bottom-0 w-1/3 h-[2px] transition-transform duration-500 ease-in-out bg-sample-blue"
                         style={{
-                            transform: `translateX(${getTranslateX(storageType)})`
+                            transform: `translateX(${getTranslateX(letterType as LetterType)})`
                         }}
                     ></div>
                     <div
                         className="flex items-center justify-center flex-1 h-full cursor-pointer"
-                        onClick={() => handleTypeChange('keyword')}
+                        onClick={() => handleNavigate('keyword')}
                     >
                         <span>키워드 편지</span>
                     </div>
                     <div
                         className="flex items-center justify-center flex-1 h-full cursor-pointer"
-                        onClick={() => handleTypeChange('map')}
+                        onClick={() => handleNavigate('map')}
                     >
                         <span>내 지도 편지</span>
                     </div>
                     <div
                         className="flex items-center justify-center flex-1 h-full cursor-pointer"
-                        onClick={() => handleTypeChange('bookmark')}
+                        onClick={() => handleNavigate('bookmark')}
                     >
                         <span>보관한 지도 편지</span>
                     </div>
@@ -62,7 +66,7 @@ export const StoragePage = ({ initialType }: StoragePageProps) => {
             </div>
 
             <div className="flex flex-col gap-2 mt-[15px]">
-                <StorageList type={storageType} />
+                <StorageList />
             </div>
         </div>
     );

--- a/src/pages/User/MyPage/MyPage.tsx
+++ b/src/pages/User/MyPage/MyPage.tsx
@@ -29,17 +29,17 @@ export const MyPage = () => {
     const menuItems = [
         {
             content: '키워드 편지함',
-            url: '/storage?type=keyword',
+            url: '/storage/keyword?filtertype=sent',
             state: { initialType: 'keyword' }
         },
         {
             content: '지도 편지함',
-            url: '/storage?type=map',
+            url: '/storage/map?filtertype=sent',
             state: { initialType: 'map' }
         },
         {
             content: '보관함',
-            url: '/storage?type=bookmark',
+            url: '/storage/bookmark',
             state: { initialType: 'bookmark' }
         }
     ];

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -99,7 +99,7 @@ export const router = createBrowserRouter([
                 element: <MyPage />
             },
             {
-                path: 'storage',
+                path: 'storage/:letterType',
                 element: <StoragePage />
             },
             {

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -7,6 +7,42 @@ export type LetterType = {
     label: string;
 };
 
+export type storageLetterType = 'keyword' | 'map' | 'bookmark';
+
+export type DeleteLetterType = {
+    letterId: number;
+    letterType: string;
+    boxType: string;
+};
+
+export type StorageKeywordLetterType = {
+    letterId: number;
+    title: string;
+    description: string;
+    latitude: number;
+    longitude: number;
+    label: string;
+    createdAt: string;
+    type: string;
+    sourceLetterId: number;
+    senderNickname: string;
+    senderProfileImg: string;
+};
+
+export type StorageMapLetterType = {
+    letterId: number;
+    title: string;
+    description: string;
+    latitude: number;
+    longitude: number;
+    label: string;
+    createdAt: string;
+    type: string;
+    sourceLetterId: number;
+    senderNickname: string;
+    senderProfileImg: string;
+};
+
 export type MapReplyType = {
     sourceLetter: number;
     content: string;


### PR DESCRIPTION
# 🚀요약
보관함 리팩토링 : 컴포넌트 분리

# 📝작업 내용

-   [x] 개별 리스트 아이템 LetterLietItem 컴포넌트로 분리
- [x] 날짜별 편지 그룹 LetterDateGroup 컴포넌트로 분리
- [x] 스토어 타입을 url 파라미터로 관리하도록 변경
- [x] 필터 타입을 쿼리파라미터로 관리하도록 변경
* getApiEndpoint / getNavigatePath 조건문을 간결하게 변경하였습니다

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
* 현재 지도 편지의 경우 백엔드 데이터 수정 대기중이라 삭제 동작하지 않으니 확인 부탁드립니다
