### PR TITLE
feat : 메인페이지 알림 버튼에 핑 추가

### DIFF
--- a/src/components/Common/NotificationBadge/NotificationBadge.tsx
+++ b/src/components/Common/NotificationBadge/NotificationBadge.tsx
@@ -12,8 +12,11 @@ export const NotificationBadge = ({ count }: NotificationBadgeProps) => {
         count > MAX_NOTIFICATION_COUNT ? `${MAX_NOTIFICATION_COUNT}+` : count;
 
     return (
-        <div className="absolute bg-[#FF6868] rounded-full text-white text-body1 flex-center h-6 px-3 leading-none">
-            {renderCount}
-        </div>
+        <span className="relative flex size-4">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#FF6868] opacity-75"></span>
+            <span className="relative inline-flex size-4 rounded-full bg-[#FF6868] text-white text-[10px] flex-center leading-none">
+                {renderCount}
+            </span>
+        </span>
     );
 };

--- a/src/components/HomePage/TopButtonContainer/TopButtonContainer.tsx
+++ b/src/components/HomePage/TopButtonContainer/TopButtonContainer.tsx
@@ -1,8 +1,20 @@
 import { NavLink } from 'react-router-dom';
 import { Logo } from '../../Common/LogoContainer/Logo';
 import { IoIosNotifications } from '@react-icons/all-files/io/IoIosNotifications';
+import { NotificationBadge } from '@/components/Common/NotificationBadge/NotificationBadge';
+import { useGetUnreadNotifications } from '@/hooks/useGetUnreadNotifications';
 
 export const TopButtonContainer = () => {
+    const { data, isLoading, isError } = useGetUnreadNotifications();
+
+    let unreadNotifications;
+
+    if (isLoading || isError || !data) {
+        unreadNotifications = 0;
+    } else {
+        unreadNotifications = data?.result.count;
+    }
+
     return (
         <div className="flex justify-between pb-8">
             <NavLink to={'/'} className="flex-center">
@@ -11,6 +23,10 @@ export const TopButtonContainer = () => {
 
             <NavLink to={'/notification'} className="size-[34px] relative">
                 <IoIosNotifications className="size-[34px] text-sample-blue" />
+
+                <div className="absolute top-0 right-0">
+                    <NotificationBadge count={unreadNotifications} />
+                </div>
             </NavLink>
         </div>
     );

--- a/src/hooks/useGetUnreadNotifications.ts
+++ b/src/hooks/useGetUnreadNotifications.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUnreadNotifications } from '@/service/notification/getUnreadNotifications';
+
+export const useGetUnreadNotifications = () => {
+    return useQuery({
+        queryKey: ['unreadNotifications'],
+        queryFn: getUnreadNotifications
+    });
+};

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -12,7 +12,6 @@ import { ToggleVariant } from '@/constants/toggleVariant';
 import { useGetThreeLetterData } from '@/hooks/useGetThreeLetterData';
 import { ErrorPage } from '../ErrorPage';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
-import { NotificationBadge } from '@/components/Common/NotificationBadge/NotificationBadge';
 
 const HomePage = () => {
     usePushNotifications(); // 푸시 알림 훅
@@ -47,10 +46,6 @@ const HomePage = () => {
                         rightLabel="답장"
                         variant={ToggleVariant.Main}
                     />
-
-                    <div className="absolute -top-2 left-32">
-                        <NotificationBadge count={letters.length} />
-                    </div>
                 </div>
 
                 {/* welcomeMessage section */}

--- a/src/service/notification/getUnreadNotifications.ts
+++ b/src/service/notification/getUnreadNotifications.ts
@@ -1,0 +1,10 @@
+import { defaultApi } from '@/service/api';
+import { unreadNotificationsType } from '@/types/unreadNotification';
+
+export const getUnreadNotifications =
+    async (): Promise<unreadNotificationsType> => {
+        const api = defaultApi();
+
+        const response = await api.get('/notification/unread');
+        return response.data;
+    };

--- a/src/types/unreadNotification.ts
+++ b/src/types/unreadNotification.ts
@@ -1,0 +1,8 @@
+export type unreadNotificationsType = {
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: {
+        count: number;
+    };
+};


### PR DESCRIPTION
# 🚀요약
메인페이지 알림 버튼에 핑 추가

# 📸사진 (구현 캡처)
![2025-02-03-10-48-39](https://github.com/user-attachments/assets/521fbb18-164c-480c-a7f5-566ac7495783)

# 📝작업 내용

-   [x] 읽지 않은 알림의 개수를 받아오는 훅 생성
-   [x] 키워드편지, 답장편지의 개수를 보여주던 `NotificationBadge` 컴포넌트의 역할을 알림 버튼 벳지로 변경
알림버튼 위에 핑 형태로 위치하면서 읽지 않은 알림의 개수를 보여줍니다.
기존 `NotificationBadge`가 키워드편지, 답장편지의 고정된 0~3개의 개수를 보여줌으로 큰 역할을 하지 않는 것 같아 수정하였습니다.

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #196
