### PR TITLE
fix : 보관함에서 편지 삭제 시 401 auth 에러가 발생하는 오류 해결

### DIFF
--- a/src/components/HomePage/LetterContainer/LetterContainer.tsx
+++ b/src/components/HomePage/LetterContainer/LetterContainer.tsx
@@ -36,14 +36,9 @@ const LetterSlide = ({ letter }: LetterSlideProps) => {
     const LetterType = 'labelUrl' in letter ? 'REPLY_LETTER' : 'LETTER';
 
     // 편지 아이디로 편지 키워드 가져오기
-    const { data, isError, error } = useKeywordLetterDetail({
+    const { data, isError } = useKeywordLetterDetail({
         letterId: String(letter.letterId)
     });
-
-    if (isError) {
-        // 임시 ui
-        return <div>삭제된 편지</div>;
-    }
 
     // 에러거나 data가 undefined일때 빈 배열
     const letterKeywords =
@@ -54,7 +49,18 @@ const LetterSlide = ({ letter }: LetterSlideProps) => {
               : data.keywords;
 
     return (
-        <>
+        <div className="relative">
+            {isError && (
+                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center justify-center bg-orange-50 text-orange-800 border border-orange-200 rounded-md z-[2] px-6 py-5 shadow-sm space-y-1 min-w-[330px]">
+                    <p className="font-medium">조회가 불가능한 편지입니다.</p>
+                    <p className="text-sm text-orange-700 text-center">
+                        작성자가 삭제한 편지나, 보관함에서 삭제 처리가 완료된
+                        편지는 열람이 불가능합니다.
+                    </p>
+                </div>
+            )}
+            {/* 클릭 방지 오버레이 레이어 */}
+            {isError && <div className="absolute inset-0 z-[1]" />}
             <div className="flex flex-wrap gap-2 absolute w-[50%] pl-6">
                 {letterKeywords.length > 0 &&
                     letterKeywords.map((keyword, i) => {
@@ -71,7 +77,6 @@ const LetterSlide = ({ letter }: LetterSlideProps) => {
                         );
                     })}
             </div>
-
             <div className="h-[380px] overflow-visible">
                 <HomeBottle
                     letterType={LetterType}
@@ -79,7 +84,7 @@ const LetterSlide = ({ letter }: LetterSlideProps) => {
                     labelUrl={labelUrl}
                 />
             </div>
-        </>
+        </div>
     );
 };
 

--- a/src/components/HomePage/LetterContainer/LetterContainer.tsx
+++ b/src/components/HomePage/LetterContainer/LetterContainer.tsx
@@ -36,29 +36,40 @@ const LetterSlide = ({ letter }: LetterSlideProps) => {
     const LetterType = 'labelUrl' in letter ? 'REPLY_LETTER' : 'LETTER';
 
     // 편지 아이디로 편지 키워드 가져오기
-    const { data } = useKeywordLetterDetail({
+    const { data, isError, error } = useKeywordLetterDetail({
         letterId: String(letter.letterId)
     });
 
+    if (isError) {
+        // 임시 ui
+        return <div>삭제된 편지</div>;
+    }
+
+    // 에러거나 data가 undefined일때 빈 배열
     const letterKeywords =
-        data.keywords.length > 9 ? data.keywords.slice(0, 9) : data.keywords;
+        isError || !data
+            ? []
+            : data.keywords.length > 9
+              ? data.keywords.slice(0, 9)
+              : data.keywords;
 
     return (
         <>
             <div className="flex flex-wrap gap-2 absolute w-[50%] pl-6">
-                {letterKeywords.map((keyword, i) => {
-                    return (
-                        <div
-                            key={i}
-                            className="bg-white border-solid rounded-full px-3 py-1 text-sample-black font-light z-[1]"
-                        >
-                            #
-                            {keyword.length > 12
-                                ? keyword.slice(0, 12) + '...'
-                                : keyword}
-                        </div>
-                    );
-                })}
+                {letterKeywords.length > 0 &&
+                    letterKeywords.map((keyword, i) => {
+                        return (
+                            <div
+                                key={i}
+                                className="bg-white border-solid rounded-full px-3 py-1 text-sample-black font-light z-[1]"
+                            >
+                                #
+                                {keyword.length > 12
+                                    ? keyword.slice(0, 12) + '...'
+                                    : keyword}
+                            </div>
+                        );
+                    })}
             </div>
 
             <div className="h-[380px] overflow-visible">

--- a/src/components/StoragePage/StorageList.tsx
+++ b/src/components/StoragePage/StorageList.tsx
@@ -106,6 +106,7 @@ export const StorageList = () => {
                 break;
             }
             case 'map': {
+                // api - 버전 2
                 // {
                 //     "letterType": 기존 편지의 deleteType
                 //     "letterId": 0
@@ -120,6 +121,7 @@ export const StorageList = () => {
                 break;
             }
             case 'bookmark': {
+                // api - 버전 2
                 // letterId 배열 [1,2,3,4...]
                 const bookmarkPayload = {
                     letterIds: checkedItems.map((item) => item.letterId)

--- a/src/hooks/useGetKeywordLetterDetail.ts
+++ b/src/hooks/useGetKeywordLetterDetail.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getKeywordLetterDetail } from '@/service/detail/getKeywordLetterDetail';
 import { GetKeywordLetterDetailResponseType } from '@/types/letter';
 
@@ -9,7 +9,7 @@ type UseKeywordLetterDetailProps = {
 export const useKeywordLetterDetail = ({
     letterId
 }: UseKeywordLetterDetailProps) => {
-    return useSuspenseQuery<GetKeywordLetterDetailResponseType, Error>({
+    return useQuery<GetKeywordLetterDetailResponseType, Error>({
         queryKey: ['keywordLetterDetail', letterId],
         queryFn: async () => {
             const response = await getKeywordLetterDetail({ letterId });

--- a/src/hooks/useGetKeywordLetterDetail.ts
+++ b/src/hooks/useGetKeywordLetterDetail.ts
@@ -15,6 +15,9 @@ export const useKeywordLetterDetail = ({
             const response = await getKeywordLetterDetail({ letterId });
             return response.result;
         },
-        retry: false
+        retry: false,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        staleTime: Infinity
     });
 };

--- a/src/service/letter/delete/deleteBookmarkLetters.ts
+++ b/src/service/letter/delete/deleteBookmarkLetters.ts
@@ -2,7 +2,7 @@ import { defaultApi } from '@/service/api';
 import { ApiResponseType } from '@/types/apiResponse';
 
 type DeleteLetterType = {
-    archiveIds: number[];
+    letterIds: number[];
 };
 
 type deleteBookmarkLettersResponse = ApiResponseType<string>;

--- a/src/service/letter/delete/deleteMapLetters.ts
+++ b/src/service/letter/delete/deleteMapLetters.ts
@@ -2,16 +2,17 @@ import { defaultApi } from '@/service/api';
 import { ApiResponseType } from '@/types/apiResponse';
 
 type DeleteLetterType = {
-    letterIds: number[];
+    letterId: number;
+    letterType: string;
 };
 
 type deleteMapLettersResponse = ApiResponseType<string>;
 
 export const deleteMapLetters = async (
-    selectedList: DeleteLetterType
+    selectedList: DeleteLetterType[]
 ): Promise<deleteMapLettersResponse> => {
     const api = defaultApi();
-    const response = await api.delete('/map', {
+    const response = await api.delete('/map/v2', {
         data: selectedList
     });
     return response.data;

--- a/src/service/letter/delete/deleteMapLetters.ts
+++ b/src/service/letter/delete/deleteMapLetters.ts
@@ -12,8 +12,9 @@ export const deleteMapLetters = async (
     selectedList: DeleteLetterType[]
 ): Promise<deleteMapLettersResponse> => {
     const api = defaultApi();
+    console.log(selectedList);
     const response = await api.delete('/map/v2', {
-        data: selectedList
+        data: { letters: selectedList }
     });
     return response.data;
 };

--- a/src/service/storage/getRecommendedLetter.ts
+++ b/src/service/storage/getRecommendedLetter.ts
@@ -15,6 +15,5 @@ export const getRecommendedLetter =
     async (): Promise<GetRecommendedLetterType> => {
         const api = defaultApi();
         const response = await api.get('/letters/recommend');
-        console.log('401에러 디버깅 getRecommendedLetter 출력:', response.data);
         return response.data;
     };

--- a/src/types/letter.ts
+++ b/src/types/letter.ts
@@ -49,6 +49,7 @@ export interface StorageMapSentLetter extends BaseLetter {
     targetUserNickname: string;
     type: string;
     sourceLetterId: number;
+    deleteType: string;
 }
 
 export interface StorageMapReceivedLetter extends BaseLetter {
@@ -59,6 +60,7 @@ export interface StorageMapReceivedLetter extends BaseLetter {
     sourceLetterId: number;
     senderNickname: string;
     senderProfileImg: string;
+    deleteType: string;
 }
 
 export interface StorageMapArchivedLetter extends BaseLetter {


### PR DESCRIPTION
# 🚀요약

# 📸사진 (구현 캡처)
![image](https://github.com/user-attachments/assets/4c3279dd-18c1-41d6-acff-9bcb2d143172)

# 📝작업 내용

-   [ ] 삭제 api를 3차 스프린트에 배포된 버전 2로 변경 후 관련 타입 수정했습니다
-   [ ] useKeywordLetterDetail 내부의 useSuspenseQuery를 useQuery로 변경했습니다. 추천편지 관련 오류는 컴포넌트 내부에서 에러분기를 직접 제어해주는 방향으로 수정하고 클릭 이벤트 처리되지 않도록 했습니다

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
보관함에서 미배포된 백엔드 api 엔드포인트 관련 함수 임시 주석처리했습니다

close #487
