### PR TITLE
fix : 지도 편지페이지에서 지도편지 상세 조회시 답장 편지로 api가 전송되는 오류 해결

### DIFF
--- a/src/components/LetterDetailPage/LetterDetailContainer/LetterDetailContainer.tsx
+++ b/src/components/LetterDetailPage/LetterDetailContainer/LetterDetailContainer.tsx
@@ -44,7 +44,7 @@ export const LetterDetailContainer = () => {
             return <MapBookmarkDetailLetter letterId={letterId} />;
         }
 
-        if (letterId) {
+        if (!lat && !lot && letterId) {
             return (
                 <MapArchivedSentReplyDetailLetter replyLetterId={letterId} />
             );


### PR DESCRIPTION
# 🚀요약
지도 편지페이지에서 지도편지 상세 조회시 답장 편지로 api가 전송되는 오류 해결 완료
# 📸사진 (구현 캡처)

# 📝작업 내용

-   [x] 지도 편지페이지에서 지도편지 상세 조회시 답장 편지로 api가 전송되는 오류 해결 완료
-   [ ]



close #503
