### PR TITLE
feat : 라벨첩 api 연결

### DIFF
--- a/src/pages/Storage/LabelCollectionsPage.tsx
+++ b/src/pages/Storage/LabelCollectionsPage.tsx
@@ -4,40 +4,26 @@ import React, { useState } from 'react';
 import { LabelType } from '@/types/label';
 import { Itembox } from '@/components/Common/Itembox/Itembox';
 import { Label } from '@/components/Common/BottleLetter/Label/Label';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useModal } from '@/hooks/useModal';
 import { Margin } from '@/components/Common/Margin/Margin';
 import { BackButtonCotainer } from '@/components/Common/BackButtonContainer/BackButtonCotainer';
-
-const testLable: LabelType[] = [
-    { labelId: 1, imageUrl: '/라벨_샘플_1.png' },
-    { labelId: 2, imageUrl: '/라벨_샘플_2.png' },
-    { labelId: 3, imageUrl: '/라벨_샘플_3.png' },
-    { labelId: 4, imageUrl: '/라벨_샘플_4.png' },
-    { labelId: 5, imageUrl: '/라벨_샘플_5.png' },
-    { labelId: 6, imageUrl: '/라벨_샘플_6.png' },
-    { labelId: 7, imageUrl: '/라벨_샘플_1.png' },
-    { labelId: 8, imageUrl: '/라벨_샘플_2.png' },
-    { labelId: 9, imageUrl: '/라벨_샘플_3.png' },
-    { labelId: 10, imageUrl: '/라벨_샘플_4.png' },
-    { labelId: 11, imageUrl: '/라벨_샘플_5.png' },
-    { labelId: 12, imageUrl: '/라벨_샘플_6.png' },
-    { labelId: 13, imageUrl: '/라벨_샘플_1.png' },
-    { labelId: 14, imageUrl: '/라벨_샘플_2.png' },
-    { labelId: 15, imageUrl: '/라벨_샘플_3.png' },
-    { labelId: 16, imageUrl: '/라벨_샘플_4.png' },
-    { labelId: 17, imageUrl: '/라벨_샘플_5.png' },
-    { labelId: 18, imageUrl: '/라벨_샘플_6.png' },
-    { labelId: 19, imageUrl: '/라벨_샘플_1.png' },
-    { labelId: 20, imageUrl: '/라벨_샘플_2.png' },
-    { labelId: 21, imageUrl: '/라벨_샘플_3.png' },
-    { labelId: 22, imageUrl: '/라벨_샘플_4.png' },
-    { labelId: 23, imageUrl: '/라벨_샘플_5.png' },
-    { labelId: 24, imageUrl: '/라벨_샘플_6.png' }
-];
+import { getUserLabel } from '@/service/label/get/getUserLabel';
+import { useQuery } from '@tanstack/react-query';
 
 export const LabelCollectionsPage = () => {
     const { openModal, closeModal, ModalComponent } = useModal();
+    const navigate = useNavigate();
+    const {
+        data: userLabelList,
+        isLoading,
+        error
+    } = useQuery({
+        queryKey: ['userLabels'],
+        queryFn: getUserLabel,
+        retry: false,
+        select: (data) => data.result
+    });
     const [selectedLabel, setSelectedLabel] = useState<LabelType | null>(null);
 
     const handleItemClick = (item: LabelType) => {
@@ -45,32 +31,33 @@ export const LabelCollectionsPage = () => {
         openModal();
     };
 
-    // const { data, isLoading, isError } = useQuery({
-    //     queryKey: ['userLabel'],
-    //     queryFn: getUserLabel,
-    //     retry: 1
-    // });
-
     const renderList = () => {
-        // if (isLoading) return <div>로딩중...</div>;
-        // if (isError) return <div>에러</div>;
-        // if (data.isSuccess) {
-        //     return (
-        //         <div className="">
-        //             {testLable.result.map((item, index) => {
-        //                 return (
-        //                     <div key={item.labelId + { index }}>
-        //                         {item.imageUrl}
-        //                     </div>
-        //                 );
-        //             })}
-        //         </div>
-        //     );
-        // }
-        // 테스트 라벨 데이터 바인딩
+        if (isLoading) return <div>로딩중...</div>;
+        if (
+            !userLabelList ||
+            (error && 'code' in error && error.code === 'LABEL4002')
+        ) {
+            console.log(error);
+            return (
+                <div className=" flex flex-col items-center justify-center mt-[35%] gap-2">
+                    <h1 className="text-5xl font-bold mb-4 text-sample-blue">
+                        텅
+                    </h1>
+                    <div className="text-xl font-semibold text-gray-700 text-center">
+                        아직 보유한 라벨이 없어요.
+                    </div>
+                    <button
+                        className="mt-2 px-4 py-2 bg-sample-blue text-white rounded-md"
+                        onClick={() => navigate('/lottery')}
+                    >
+                        라벨 뽑으러 가기
+                    </button>
+                </div>
+            );
+        }
         return (
             <div className="grid grid-cols-4 gap-4 w-full">
-                {testLable.map((item, index) => {
+                {userLabelList.map((item, index) => {
                     return (
                         <Itembox
                             key={item.labelId + index}

--- a/src/service/label/get/getUserLabel.ts
+++ b/src/service/label/get/getUserLabel.ts
@@ -6,7 +6,6 @@ type GetUserLabelResponseType = ApiResponseType<LabelType[]>;
 
 export const getUserLabel = async (): Promise<GetUserLabelResponseType> => {
     const api = defaultApi();
-
     const response = await api.get('/labels/user');
     console.log('라벨응답:', response);
     return response.data;


### PR DESCRIPTION
# 🚀요약

# 📸사진 (구현 캡처)
![image](https://github.com/user-attachments/assets/a0e2b731-915d-46d6-ac50-3c8b1a6f128e)


# 📝작업 내용

-   [ ] 더미 데이터로 연결되어있던 라벨첩에 api로 데이터 패치 후 리스트 보여지도록 변경했습니다
- [ ] 사용자에게 기본 라벨이 없을 경우 emptyList 컴포넌트와 동일한 레이아웃으로 임시 연결해두었으며 라벨 뽑기 페이지로 이동하도록 하였습니다! 추후에 emptyList 컴포넌트 메세지를 props로 받을 수 있도록 수정하면 좋을듯합니다

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #502 
